### PR TITLE
Add instructions and scripts for result analysis

### DIFF
--- a/spark_eventlog_analyze.py
+++ b/spark_eventlog_analyze.py
@@ -1,0 +1,384 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Stream a Spark event log (JSON-lines) and compute per-SQL execution breakdown:
+- makespan_ms (wall clock for the SQL: first task start -> last task end)
+- task_slot_ms (sum of task wall times; "slot time")
+- executor_run_ms (sum of per-task executorRunTime)
+- executor_cpu_ms (sum of per-task executorCpuTime, ns -> ms)
+- cpu_vs_wall_pct (executor_cpu_ms as % of wall clock makespan)
+- plus a few useful sub-metrics (deserialize/result-serialize/shuffle wait/GC, bytes)
+
+Mapping chain:
+  TaskEnd(stageId) -> Stage -> JobStart(jobId) -> Properties["spark.sql.execution.id"] -> SQLExecutionStart(executionId)
+
+Usage:
+  python spark_eventlog_analyze.py -o run-1.csv /path/to/eventlog.json
+  python spark_eventlog_analyze.py --output-file run-2.csv /path/to/eventlog.json.gz
+  python spark_eventlog_analyze.py /path/to/eventlog.zip
+"""
+
+import argparse
+import csv
+import gzip
+import json
+import re
+import statistics
+import sys
+import zipfile
+import io
+from pprint import pprint
+from collections import defaultdict
+from contextlib import contextmanager
+
+# ---------- helpers ----------
+
+def _g(d, *keys, default=None):
+    """Return first present key from keys in dict d, else default."""
+    for k in keys:
+        if isinstance(d, dict) and k in d:
+            return d[k]
+    return default
+
+def _norm_properties(props):
+    """
+    Normalize JobStart.Properties into a dict.
+    It can be a dict already, or an array of {"key": "...", "value": "..."}.
+    """
+    if not props:
+        return {}
+    if isinstance(props, dict):
+        out = {}
+        for k, v in props.items():
+            if isinstance(v, dict) and "value" in v and len(v) == 1:
+                out[k] = v["value"]
+            else:
+                out[k] = v
+        return out
+    if isinstance(props, list):
+        out = {}
+        for p in props:
+            if not isinstance(p, dict):
+                continue
+            k = p.get("key")
+            v = p.get("value")
+            if k is not None:
+                out[k] = v
+        return out
+    return {}
+
+@contextmanager
+def _open_maybe_gz_or_zip(path):
+    if path.endswith(".gz"):
+        with gzip.open(path, "rt", encoding="utf-8", errors="replace") as f:
+            yield f
+    elif path.endswith(".zip"):
+        with zipfile.ZipFile(path, 'r') as z:
+            names = z.namelist()
+            with z.open(names[0]) as fb:
+                with io.TextIOWrapper(fb, encoding="utf-8") as f:
+                    yield f
+    else:
+        with open(path, "r", encoding="utf-8", errors="replace") as f:
+            yield f
+
+def _ms_from_ns(ns_val):
+    try:
+        return float(ns_val) / 1e6
+    except Exception:
+        return 0.0
+
+def _as_int(x, default=0):
+    try:
+        return int(x)
+    except Exception:
+        return default
+
+def _success_from_task_end(ev):
+    """
+    Try to determine if the task ended successfully. We try a few shapes:
+      ev["Task End Reason"] may be a string "Success" or an object with Reason=Success.
+    If we can't tell, we default to True to avoid dropping data.
+    """
+    r = _g(ev, "Task End Reason", "taskEndReason", default=None)
+    if r is None:
+        return True
+    if isinstance(r, str):
+        return r.lower() == "success"
+    if isinstance(r, dict):
+        reason = _g(r, "Reason", "reason", default=None)
+        if isinstance(reason, str):
+            return reason.lower() == "success"
+    rs = str(r)
+    return ("Success" in rs) or ("org.apache.spark.Success" in rs)
+
+def analyze_sql_breakdown(paths):
+    """
+    Parse one or more event log files (JSON lines) and return a list of dicts with per-execution stats.
+    """
+
+    # Maps we build while streaming
+    exec_info = {}                 # executionId -> {description, details, startTime, endTime}
+    exec_jobs = defaultdict(set)   # executionId -> set(jobIds)
+    job_exec = {}                  # jobId -> executionId
+    stage_job = {}                 # stageId -> jobId
+    tasks_by_key = {}              # (stageId, taskId) -> task record (prefer success)
+
+    # Streaming parse
+    for path in paths:
+        with _open_maybe_gz_or_zip(path) as f:
+            for line in f:
+                if not line.strip():
+                    continue
+                try:
+                    ev = json.loads(line)
+                except Exception:
+                    continue
+
+                et = _g(ev, "Event", "event")
+                if not et:
+                    continue
+
+                # --- SQL start/end/info ---
+                if et in ("org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionStart",
+                          "SparkListenerSQLExecutionStart"):
+                    exid = _as_int(_g(ev, "executionId", "Execution ID", default=None), default=None)
+                    if exid is None:
+                        continue
+                    exec_info.setdefault(exid, {})
+                    exec_info[exid]["description"] = (_g(ev, "description", "Description", default="") or "").strip()
+                    exec_info[exid]["details"] = _g(ev, "details", "Details", default="")
+                    st = _g(ev, "time", "Time", "startTime", "Start Time", default=None)
+                    if st is not None:
+                        exec_info[exid]["startTime"] = _as_int(st, default=None)
+
+                elif et in ("org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd",
+                            "SparkListenerSQLExecutionEnd"):
+                    exid = _as_int(_g(ev, "executionId", "Execution ID", default=None), default=None)
+                    if exid is not None:
+                        ex = exec_info.setdefault(exid, {})
+                        en = _g(ev, "time", "Time", "endTime", "End Time", default=None)
+                        if en is not None:
+                            ex["endTime"] = _as_int(en, default=None)
+
+                # --- JobStart: tie job -> executionId and stageIds -> jobId ---
+                elif et == "SparkListenerJobStart":
+                    jobId = _as_int(_g(ev, "Job ID", "jobId", default=None), default=None)
+                    if jobId is None:
+                        continue
+
+                    stage_ids = _g(ev, "Stage IDs", "stageIds", default=None)
+                    if stage_ids is None:
+                        infos = _g(ev, "Stage Infos", "stageInfos", default=[]) or []
+                        stage_ids = [_as_int(_g(si, "Stage ID", "stageId"), default=None) for si in infos]
+                        stage_ids = [sid for sid in stage_ids if sid is not None]
+                    else:
+                        stage_ids = [_as_int(s, default=None) for s in stage_ids if s is not None]
+
+                    props = _norm_properties(_g(ev, "Properties", "properties", default={}))
+                    exid_str = props.get("spark.sql.execution.id")
+                    if exid_str is not None:
+                        try:
+                            exid = int(exid_str)
+                            job_exec[jobId] = exid
+                            exec_jobs[exid].add(jobId)
+                        except Exception:
+                            pass
+
+                    for sid in stage_ids:
+                        if sid is not None:
+                            stage_job[sid] = jobId
+
+                # --- TaskEnd: collect per-task metrics (we'll attribute to exec later) ---
+                elif et == "SparkListenerTaskEnd":
+                    stageId = _as_int(_g(ev, "Stage ID", "stageId", default=None), default=None)
+                    if stageId is None:
+                        continue
+
+                    taskInfo = _g(ev, "Task Info", "taskInfo", "TaskInfo", default={}) or {}
+                    metrics = _g(ev, "Task Metrics", "taskMetrics", "TaskMetrics", default={}) or {}
+
+                    task_id = _as_int(_g(taskInfo, "Task ID", "taskId", "TaskId", default=None), default=None)
+                    key = (stageId, task_id)
+
+                    launch = _g(taskInfo, "Launch Time", "launchTime")
+                    finish = _g(taskInfo, "Finish Time", "finishTime")
+                    launch_i = _as_int(launch, default=None) if launch is not None else None
+                    finish_i = _as_int(finish, default=None) if finish is not None else None
+                    if launch_i is not None and finish_i is not None:
+                        duration_ms = max(0, finish_i - launch_i)
+                    else:
+                        duration_ms = _as_int(_g(metrics, "Executor Run Time", "executorRunTime", default=0), default=0)
+
+                    run_ms = _as_int(_g(metrics, "Executor Run Time", "executorRunTime", default=0), default=0)
+                    cpu_ns = _as_int(_g(metrics, "Executor CPU Time", "executorCpuTime", default=0), default=0)
+                    cpu_ms = cpu_ns / 1e6
+
+                    deser_ms = _as_int(_g(metrics, "Executor Deserialize Time",
+                                          "executorDeserializeTime", default=0), default=0)
+                    result_ser_ms = _as_int(_g(metrics, "Result Serialization Time",
+                                               "resultSerializationTime", default=0), default=0)
+                    gc_ms = _as_int(_g(metrics, "JVM GC Time", "JvmGcTime", "jvmGcTime", default=0), default=0)
+
+                    shuffle_read = _g(metrics, "Shuffle Read Metrics", "shuffleReadMetrics", default={}) or {}
+                    shuffle_write = _g(metrics, "Shuffle Write Metrics", "shuffleWriteMetrics", default={}) or {}
+                    input_metrics = _g(metrics, "Input Metrics", "inputMetrics", default={}) or {}
+                    output_metrics = _g(metrics, "Output Metrics", "outputMetrics", default={}) or {}
+
+                    shuffle_fetch_wait_ms = _as_int(_g(shuffle_read, "Fetch Wait Time",
+                                                       "fetchWaitTime", default=0), default=0)
+                    shuffle_read_bytes = _as_int(_g(shuffle_read, "Remote Bytes Read",
+                                                    "remoteBytesRead", default=0), default=0)
+                    shuffle_read_bytes += _as_int(_g(shuffle_read, "Local Bytes Read",
+                                                     "localBytesRead", default=0), default=0)
+
+                    shuffle_write_time_ms = _ms_from_ns(_g(shuffle_write, "Write Time",
+                                                           "writeTime", default=0))
+                    shuffle_write_bytes = _as_int(_g(shuffle_write, "Bytes Written",
+                                                     "bytesWritten", default=0), default=0)
+
+                    input_bytes = _as_int(_g(input_metrics, "Bytes Read", "bytesRead", default=0), default=0)
+                    output_bytes = _as_int(_g(output_metrics, "Bytes Written", "bytesWritten", default=0), default=0)
+
+                    success = _success_from_task_end(ev)
+
+                    t_rec = {
+                        "stageId": stageId,
+                        "taskId": task_id,
+                        "launch": launch_i,
+                        "finish": finish_i,
+                        "duration_ms": duration_ms,
+                        "run_ms": run_ms,
+                        "cpu_ms": cpu_ms,
+                        "deserialize_ms": deser_ms,
+                        "result_serialize_ms": result_ser_ms,
+                        "gc_ms": gc_ms,
+                        "shuffle_fetch_wait_ms": shuffle_fetch_wait_ms,
+                        "shuffle_write_time_ms": shuffle_write_time_ms,
+                        "shuffle_read_bytes": shuffle_read_bytes,
+                        "shuffle_write_bytes": shuffle_write_bytes,
+                        "input_bytes": input_bytes,
+                        "output_bytes": output_bytes,
+                        "success": success,
+                    }
+
+                    prev = tasks_by_key.get(key)
+                    if prev is None or (not prev.get("success") and success):
+                        tasks_by_key[key] = t_rec
+
+    # Attribute deduped tasks -> (stage -> job -> execution)
+    tasks = list(tasks_by_key.values())
+    tasks_by_exec = defaultdict(list)
+
+    for t in tasks:
+        jobId = stage_job.get(t["stageId"])
+        if jobId is None:
+            continue
+        exid = job_exec.get(jobId)
+        if exid is None:
+            continue
+        tasks_by_exec[exid].append(t)
+
+    # Aggregate per execution
+    results = []
+    for exid, ts in tasks_by_exec.items():
+        if not ts:
+            continue
+
+        wall_start = min((t["launch"] for t in ts if t["launch"] is not None), default=None)
+        wall_end   = max((t["finish"] for t in ts if t["finish"] is not None), default=None)
+        makespan_ms = (wall_end - wall_start) if (wall_start is not None and wall_end is not None) else None
+
+        task_slot_ms = sum(t["duration_ms"] for t in ts)
+        run_ms       = sum(t["run_ms"] for t in ts)
+        cpu_ms       = sum(t["cpu_ms"] for t in ts)
+        deser_ms     = sum(t["deserialize_ms"] for t in ts)
+        result_ser   = sum(t["result_serialize_ms"] for t in ts)
+        gc_ms        = sum(t["gc_ms"] for t in ts)
+        fetch_wait   = sum(t["shuffle_fetch_wait_ms"] for t in ts)
+        shw_time_ms  = sum(t["shuffle_write_time_ms"] for t in ts)
+
+        in_bytes     = sum(t["input_bytes"] for t in ts)
+        out_bytes    = sum(t["output_bytes"] for t in ts)
+        sh_r_bytes   = sum(t["shuffle_read_bytes"] for t in ts)
+        sh_w_bytes   = sum(t["shuffle_write_bytes"] for t in ts)
+
+        # NEW: CPU vs Wall %
+        if run_ms and run_ms > 0:
+            cpu_vs_wall_pct = (cpu_ms / float(run_ms)) * 100.0
+        else:
+            cpu_vs_wall_pct = None
+
+        info = exec_info.get(exid, {})
+        desc = (info.get("description") or "").strip()
+        results.append({
+            "executionId": exid,
+            "description": desc,
+            "num_jobs": len(exec_jobs.get(exid, [])),
+            "num_tasks": len(ts),
+            "makespan_ms": makespan_ms,
+            "task_slot_ms": task_slot_ms,
+            "executor_run_ms": run_ms,
+            "executor_cpu_ms": cpu_ms,
+            "cpu_vs_wall_pct": cpu_vs_wall_pct,  # <-- new column
+            "deserialize_ms": deser_ms,
+            "result_serialize_ms": result_ser,
+            "gc_ms": gc_ms,
+            "shuffle_fetch_wait_ms": fetch_wait,
+            "shuffle_write_time_ms": shw_time_ms,
+            "input_bytes": in_bytes,
+            "output_bytes": out_bytes,
+            "shuffle_read_bytes": sh_r_bytes,
+            "shuffle_write_bytes": sh_w_bytes,
+        })
+
+    results.sort(key=lambda r: r.get("executionId") or -1)
+    return results
+
+def write_csv(f, rows):
+    fieldnames = [
+        "executionId",
+        "description",
+        "num_jobs",
+        "num_tasks",
+        "makespan_ms",
+        "task_slot_ms",
+        "executor_run_ms",
+        "executor_cpu_ms",
+        "cpu_vs_wall_pct",
+        "deserialize_ms",
+        "result_serialize_ms",
+        "gc_ms",
+        "shuffle_fetch_wait_ms",
+        "shuffle_write_time_ms",
+        "input_bytes",
+        "output_bytes",
+        "shuffle_read_bytes",
+        "shuffle_write_bytes",
+    ]
+    w = csv.DictWriter(f, fieldnames=fieldnames, quoting=csv.QUOTE_NONNUMERIC)
+    w.writeheader()
+    for row in rows:
+        w.writerow(row)
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Compute per-SQL breakdown from Spark event log(s).")
+    ap.add_argument("eventlogs", nargs="+", help="Path(s) to Spark event log JSON (optionally .gz or .zip).")
+    ap.add_argument("-o", "--output-file", help="Path where to write CSV output (stdout by default).")
+    args = ap.parse_args()
+
+    rows = analyze_sql_breakdown(args.eventlogs)
+    if not rows:
+        print("No SQL executions found (or no mappable tasks). "
+              "Make sure the log contains SQL events and JobStart with spark.sql.execution.id.", file=sys.stderr)
+        return 2
+
+    if args.output_file:
+        with open(args.output_file, "w", newline="", encoding="utf-8") as f:
+            write_csv(f, rows)
+    else:
+        write_csv(sys.stdout, rows)
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tpcds_eventlog_compare.py
+++ b/tpcds_eventlog_compare.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Compare two sets of CSV files with analyzed Spark Event logs, and get
+comparison of TPC-DS results in those runs.
+
+Usage:
+  python tpcds_eventlog_compare.py corretto-*.csv zing-*.csv
+  python tpcds_eventlog_compare.py -o first_run_only corretto-1.csv zing-1.csv
+  python tpcds_eventlog_compare.py --longer-than 60 corretto-*.csv zing-*.cs
+"""
+
+import sys
+import argparse
+import polars as pl
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+from pathlib import Path
+from matplotlib.ticker import PercentFormatter
+
+def read_spark_log_csv(config, run, path):
+    # read csv from spark_eventlog_analyzer.py
+    df = pl.read_csv(path)
+    # find the Spark queries that correspond to TPC-DS queries
+    # and add query column to identify them and extract only the columns we care about
+    df = df.filter(pl.col('description').str.contains(r'benchmark q.*')).select(
+        pl.col('description').str.strip_prefix("benchmark ").str.strip_suffix("-v2.4").alias('query'),
+        pl.col('executionId'),
+        pl.col('makespan_ms').alias('total_time'),
+        pl.col('executor_run_ms').alias('executor_time'),
+        pl.col('executor_cpu_ms').alias('executor_cpu_time'),
+    )
+    # enhance with config and run columns
+    df = df.select(pl.lit(config).alias('config'), pl.lit(run).alias('run'), pl.all())
+    return df
+
+def split_filename(path):
+    # we split name like "corretto-1.csv" to config="corretto", run=1
+    config, run = path.stem.rsplit("-", 1)
+    return config, int(run)
+
+def plot_scurve(df, metric, baseline, target, output_dir):
+    df = df.select(
+        pl.col("query"),
+        # calculate ratio as 100 * ((baseline - target) - 1)
+        (100 * ((pl.col(f"{metric}_{baseline}") / pl.col(f"{metric}_{target}")) - 1)).alias("ratio"),
+    )
+
+    # sort by ratio
+    df = df.sort("ratio")
+
+    colors = df["ratio"].map_elements(lambda ratio: "green" if ratio >= 0 else "red")
+
+    fig, ax = plt.subplots(figsize=(18, 9))
+
+    ax.bar(df["query"], df["ratio"], color=colors)
+    ax.axhline(0, color="black", linewidth=0.8)
+    ax.set_xlabel("Query")
+    ax.set_ylabel(f"Relative speedup ({baseline} / {target} - 1)")
+    fig.suptitle(f"{metric} ({target} vs {baseline} baseline)")
+    ax.set_title(f"mean {df["ratio"].mean():.2f} %, median {df["ratio"].median():.2f} %")
+    ax.tick_params(axis='x', rotation=90)
+    ax.yaxis.set_major_formatter(PercentFormatter())
+    ax.grid(axis="y", alpha=0.5)
+    fig.tight_layout()
+
+    # save to file
+    fig.savefig(output_dir / f"{target}-vs-{baseline}-{metric}.png")
+
+def main():
+    ap = argparse.ArgumentParser(description="Compare TPC-DS results in analyzed Spark event log CSVs ")
+    ap.add_argument("csv_files", nargs="+", type=Path, help="Path(s) to analyzed Spark event log CSVs in form /path/to/{config}-{run}.csv, e.g. corretto-1.csv")
+    ap.add_argument("-o", "--output-dir", type=Path, default=Path.cwd(), help="Path where to write the resulting artifacts output (current directory by default).")
+    ap.add_argument("--longer-than", type=float, default=0.0, help="Consider only queries where target runs at least this number of seconds")
+    args = ap.parse_args()
+
+    paths = args.csv_files
+
+    # select baseline based on first file name
+    baseline = split_filename(paths[0])[0]
+
+    # figure out the target to compare to (the other config)
+    configs = set(split_filename(p)[0] for p in paths)
+    if len(configs) != 2:
+        raise ValueError(f"Expected two configurations, found {configs}")
+    target = (configs - {baseline}).pop()
+
+    data_cols = ('total_time', 'executor_time', 'executor_cpu_time')
+
+    # load all data into one data frame (columns: config, run, executionId, query, total_time, etc.)
+    df = pl.concat(read_spark_log_csv(config, run, path) for config, run, path in ((*split_filename(p), p) for p in paths))
+
+    # aggregate over iterations intra-run by taking the last iteration (maximum executionId)
+    df = df.filter(pl.col("executionId") == pl.col("executionId").max().over("config", "run", "query"))
+
+    # aggregate over runs by taking mean
+    df = df.group_by(["config", "query"]).agg([pl.col(col).mean() for col in data_cols])
+
+    # pivot, and create config specific columns, e.g. total_time-corretto
+    df = df.pivot(on="config", index="query")
+
+    # apply user specified "target longer than" query filter
+    df = df.filter(pl.col(f"total_time_{target}") > args.longer_than * 1000)
+
+    # save dataframe as CSV
+    args.output_dir.mkdir(exist_ok=True)
+    df.write_csv(args.output_dir / f"{target}-vs-{baseline}.csv", quote_style='non_numeric')
+
+    # plot S-curve and save to file
+    plot_scurve(df, 'total_time', baseline, target, args.output_dir)
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Best resource for analyzing the results is Spark Event logs, as they contain all the information.

This MR add two-level option to compare Spark Event Logs with TPC-DS results:

1. Generic script to convert Spark Event Log to aggregated CSV form, where all task level metrics are summed up per "Spark query".

2. TPC-DS specific script that takes the above CSVs from multiple runs of two configurations (e.g. `zing-1.csv`, `zing-2.csv`, `corretto-1.csv`, `corretto-2.csv`), and aggregates intra-run and inter-run and pivots to produce per-query comparison of the two configurations (CSV with raw results + PNG S-curve).

I didn't add much knobs to either script, but they are fairly focused and straightforward to extend / modify.